### PR TITLE
Add MaliLib as dependency to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,7 @@
   "depends": {
     "fabricloader": ">=0.12.12",
     "fabric": "*",
-    "minecraft": ">=1.18"
+    "minecraft": ">=1.18",
+    "malilib": ">=0.11.3 <0.12"
   }
 }


### PR DESCRIPTION
Note: Version range is taken directly from MiniHUD repository, if different, please edit.